### PR TITLE
Fix endpoint missing slash

### DIFF
--- a/xoxzo/cloudpy/cloudpy.py
+++ b/xoxzo/cloudpy/cloudpy.py
@@ -117,7 +117,7 @@ class XoxzoClient:
         :rtype: XoxzoResponse
         '''
 
-        url = self.xoxzo_api_sms_url + msgid
+        url = self.xoxzo_api_sms_url + msgid + '/'
         try:
             req_res = requests.get(url, auth=(self.sid, self.auth_token))
             return (self.__parse(req_res))
@@ -222,7 +222,7 @@ class XoxzoClient:
         :rtype: XoxzoResponse.
         '''
 
-        url = self.xoxzo_api_call_url + callid
+        url = self.xoxzo_api_call_url + callid + '/'
         try:
             req_res = requests.get(url, auth=(self.sid, self.auth_token))
             return (self.__parse(req_res))


### PR DESCRIPTION
Django 2.x need the trailing slash